### PR TITLE
Actually unsubscribe from events

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -1582,6 +1582,7 @@ subProto.subscribe = function() {
 subProto.unsubscribe = function () {
     this._setUnsubscribed();
     this._centrifuge._unsubscribe(this);
+    this.removeAllListeners();
 };
 
 subProto.publish = function (data) {


### PR DESCRIPTION
When subscribing to a previously unsubscribed channel, the listener is called twice. And incrementing with every re-subscription. This fix uses EventEmiter's `removeAllListeners()` to complete unsubscribe.
Hopefully it doesn't break anything. 
Thanks!